### PR TITLE
Add caveat about reload extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Sensor data is obtained from the system using hwmon and GTop. Core Coding and th
 
 ## Development Commands
 * Reload extension `gnome-shell-extension-tool -r Vitals@CoreCoding.com`
+  - Note: This command is no longer supported as of GNOME 3.34
 * Launch preferences `gnome-shell-extension-prefs Vitals@CoreCoding.com`
 * View logs ```journalctl --since="`date '+%Y-%m-%d %H:%M'`" -f | grep Vitals```
 * Compile schemas `glib-compile-schemas --strict schemas/`


### PR DESCRIPTION
When running the extension reload command, on Ubuntu 19.10 (3.34) and Ubuntu 20.04 (3.36) you get `Reloading extensions does not work correctly and is no longer supported`.