### PR TITLE
Ensure icons are centered vertically

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -64,7 +64,7 @@ const VitalsMenuButton = new Lang.Class({
         this._menuLayout = new St.BoxLayout({
             vertical: false,
             clip_to_allocation: true,
-            x_align: Clutter.ActorAlign.START,
+            x_align: Clutter.ActorAlign.CENTER,
             y_align: Clutter.ActorAlign.CENTER,
             reactive: true,
             x_expand: true,

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -1,16 +1,48 @@
-.vitals-icon { icon-size: 16px; }
+.vitals-icon {
+    icon-size: 16px;
+}
+
 .vitals-menu-button-container {}
-.vitals-panel-icon-temperature { margin: 0 1px 0 8px; padding: 0; }
-.vitals-panel-icon-voltage { margin: 0 0 0 8px; padding: 0; }
-.vitals-panel-icon-fan { margin: 0 4px 0 8px; padding: 0; }
-.vitals-panel-icon-memory { margin: 0 2px 0 8px; padding: 0; }
-.vitals-panel-icon-processor { margin: 0 3px 0 8px; padding: 0; }
-.vitals-panel-icon-system { margin: 0 3px 0 8px; padding: 0; }
-.vitals-panel-icon-network { margin: 0 3px 0 8px; padding: 0; }
-.vitals-panel-icon-storage { margin: 0 2px 0 8px; padding: 0; }
-.vitals-panel-icon-battery { margin: 0 4px 0 8px; padding: 0; }
-.vitals-panel-label { margin: 0 3px 0 0; padding: 0; }
-.vitals-button-action { -st-icon-style: symbolic; border-radius: 32px; margin: 0px; min-height: 22px; min-width: 22px; padding: 10px; font-size: 100%; border: 1px solid transparent; }
-.vitals-button-action:hover, .vitals-button-action:focus { border-color: #777; }
-.vitals-button-action > StIcon { icon-size: 16px; }
-.vitals-button-box { padding: 0px; spacing: 22px; }
+
+.vitals-panel-icon-temperature,
+.vitals-panel-icon-voltage,
+.vitals-panel-icon-fan,
+.vitals-panel-icon-memory,
+.vitals-panel-icon-processor,
+.vitals-panel-icon-system,
+.vitals-panel-icon-network,
+.vitals-panel-icon-storage,
+.vitals-panel-icon-battery {
+    margin: 0 4px;
+    padding: 0;
+}
+
+.vitals-panel-label {
+    margin: 0 1.5px;
+    padding: 0;
+}
+
+.vitals-button-action {
+    -st-icon-style: symbolic;
+    border-radius: 32px;
+    margin: 0px;
+    min-height: 22px;
+    min-width: 22px;
+    padding: 10px;
+    font-size: 100%;
+    border: 1px solid transparent;
+}
+
+.vitals-button-action:hover,
+.vitals-button-action:focus {
+    border-color: #777;
+}
+
+.vitals-button-action>StIcon {
+    icon-size: 16px;
+}
+
+.vitals-button-box {
+    padding: 0px;
+    spacing: 22px;
+}


### PR DESCRIPTION
While using the material-shell extension I noticed that the alignment of the vitals extension was different. This PR is an attempt to resolve this alignment by setting the clutter x start to CENTER and applying equal margin to the left and right of the icons and labels. Screenshots are below.

Thanks for an awesome extension!

Traditional Gnome shell horizontal layout
![image](https://user-images.githubusercontent.com/3703/93658484-de554000-fa09-11ea-9779-5a38daaff2dd.png)

Material shell status bar - BEFORE
![image](https://user-images.githubusercontent.com/3703/93658615-2e80d200-fa0b-11ea-925e-37e26931ad9e.png)

Material shell status bar - AFTER
![image](https://user-images.githubusercontent.com/3703/93658601-08f3c880-fa0b-11ea-84bc-85d5b7d36d55.png)
