### PR TITLE
Filter temp and fan speed before average

### DIFF
--- a/values.js
+++ b/values.js
@@ -248,6 +248,14 @@ var Values = new Lang.Class({
             // process average values
             if (type == 'temperature' || type == 'voltage' || type == 'fan') {
                 let vals = Object.values(this._history[type]).map(x => parseFloat(x[1]));
+		if (type == 'fan') {
+		  filtered = vals.filter(item => item !== 0);
+		  vals = filtered;
+		}
+		else if (type == 'temperature') {
+		  filtered = vals.filter(item => item >= 0 && item < 130000);
+		  vals = filtered;
+		}
                 let sum = vals.reduce(function(a, b) { return a + b; });
                 let avg = sum / vals.length;
                 avg = this._legible(avg, format);


### PR DESCRIPTION
Fixes the average function to only use fan speeds above 0, and temperatures between 1 and 130 degree
See discussion at #149 