### PR TITLE
devel Gnome40 Subdialog formatting fixed

### DIFF
--- a/prefs.js
+++ b/prefs.js
@@ -111,7 +111,7 @@ const Settings = new Lang.Class({
 
                 let dialog = new Gtk.Dialog({ title: _(title + ' Preferences'),
                                               transient_for: this.widget.get_root(),
-                                              use_header_bar: true,
+                                              use_header_bar: false,
                                               modal: true });
 
                 let box = this.builder.get_object(sensor + '_prefs');

--- a/schemas/prefs.ui
+++ b/schemas/prefs.ui
@@ -11,6 +11,8 @@
     <property name="can_focus">0</property>
     <property name="margin_top">12</property>
     <property name="margin_bottom">12</property>
+    <property name="margin_start">6</property>
+    <property name="margin_end">6</property>
     <property name="orientation">vertical</property>
     <child>
       <object class="GtkFrame">
@@ -31,6 +33,7 @@
                     <property name="margin_bottom">6</property>
                     <property name="margin_start">6</property>
                     <property name="margin_end">6</property>
+                    <property name="spacing">12</property>
                     <child>
                       <object class="GtkLabel">
                         <property name="hexpand">1</property>
@@ -57,6 +60,8 @@
                     <property name="can_focus">0</property>
                     <property name="margin_top">6</property>
                     <property name="margin_bottom">6</property>
+                    <property name="margin_start">6</property>
+                    <property name="margin_end">6</property>
                     <child>
                       <object class="GtkLabel">
                         <property name="hexpand">1</property>
@@ -752,6 +757,8 @@
     <property name="can_focus">0</property>
     <property name="margin_top">12</property>
     <property name="margin_bottom">12</property>
+    <property name="margin_start">6</property>
+    <property name="margin_end">6</property>
     <property name="orientation">vertical</property>
     <child>
       <object class="GtkFrame">
@@ -770,6 +777,9 @@
                     <property name="can_focus">0</property>
                     <property name="margin_top">6</property>
                     <property name="margin_bottom">6</property>
+                    <property name="margin_start">6</property>
+                    <property name="margin_end">6</property>
+                    <property name="spacing">12</property>
                     <child>
                       <object class="GtkLabel">
                         <property name="hexpand">1</property>
@@ -797,6 +807,8 @@
                     <property name="valign">center</property>
                     <property name="margin_top">6</property>
                     <property name="margin_bottom">6</property>
+                    <property name="margin_start">6</property>
+                    <property name="margin_end">6</property>
                     <child>
                       <object class="GtkLabel">
                         <property name="hexpand">1</property>
@@ -828,6 +840,8 @@
     <property name="can_focus">0</property>
     <property name="margin_top">12</property>
     <property name="margin_bottom">12</property>
+    <property name="margin_start">6</property>
+    <property name="margin_end">6</property>
     <property name="orientation">vertical</property>
     <child>
       <object class="GtkFrame">
@@ -846,18 +860,22 @@
                     <property name="can_focus">0</property>
                     <property name="margin_top">6</property>
                     <property name="margin_bottom">6</property>
+                    <property name="margin_start">6</property>
+                    <property name="margin_end">6</property>
+                    <property name="spacing">12</property>
                     <child>
                       <object class="GtkLabel">
                         <property name="hexpand">1</property>
                         <property name="can_focus">0</property>
                         <property name="halign">start</property>
-                        <property name="label" translatable="yes">Unit</property>
+                        <property name="label" translatable="yes">Unit                </property>
                       </object>
                     </child>
                     <child>
                       <object class="GtkComboBoxText" id="unit">
                         <property name="can_focus">0</property>
                         <property name="active">0</property>
+                        <property name="halign">end</property>
                         <items>
                           <item translatable="no">°C</item>
                           <item translatable="no">°F</item>
@@ -877,6 +895,8 @@
     <property name="can_focus">0</property>
     <property name="margin_top">12</property>
     <property name="margin_bottom">12</property>
+    <property name="margin_start">6</property>
+    <property name="margin_end">6</property>
     <property name="orientation">vertical</property>
     <child>
       <object class="GtkFrame">
@@ -895,6 +915,9 @@
                     <property name="can_focus">0</property>
                     <property name="margin_top">6</property>
                     <property name="margin_bottom">6</property>
+                    <property name="margin_start">6</property>
+                    <property name="margin_end">6</property>
+                    <property name="spacing">12</property>
                     <child>
                       <object class="GtkLabel">
                         <property name="hexpand">1</property>
@@ -926,6 +949,8 @@
     <property name="can_focus">0</property>
     <property name="margin_top">12</property>
     <property name="margin_bottom">12</property>
+    <property name="margin_start">6</property>
+    <property name="margin_end">6</property>
     <property name="orientation">vertical</property>
     <child>
       <object class="GtkFrame">
@@ -944,12 +969,15 @@
                     <property name="can_focus">0</property>
                     <property name="margin_top">6</property>
                     <property name="margin_bottom">6</property>
+                    <property name="margin_start">6</property>
+                    <property name="margin_end">6</property>
+                    <property name="spacing">12</property>
                     <child>
                       <object class="GtkLabel">
                         <property name="hexpand">1</property>
                         <property name="can_focus">0</property>
                         <property name="halign">start</property>
-                        <property name="label" translatable="yes">Display battery</property>
+                        <property name="label" translatable="yes">Display Battery</property>
                       </object>
                     </child>
                     <child>


### PR DESCRIPTION
Changed the pref.js dialog creation call to set use_header_bar : false and added some related formatting statements to prefs.ui. This provides more consistent and readable sub-preference dialogs. There is still one nagging issue where I haven't been able to find the magic setting to get the temperature_pref dialog layout to generate a layout wide enough that the title bar label doesn't get cut off.

These changes are additional, incremental updates beyond the changes from my initial pull request.