### PR TITLE
Fix missing system monitor icon

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -139,7 +139,7 @@ var VitalsMenuButton = GObject.registerClass({
         customButtonBox.add_actor(refreshButton);
 
         // custom round monitor button
-        let monitorButton = this._createRoundButton('utilities-system-monitor-symbolic', _('System Monitor'));
+        let monitorButton = this._createRoundButton('org.gnome.SystemMonitor-symbolic', _('System Monitor'));
         monitorButton.connect('clicked', (self) => {
             this.menu._getTopMenu().close();
             Util.spawn(['gnome-system-monitor']);


### PR DESCRIPTION
**Before Fix**
![Before](https://user-images.githubusercontent.com/44396182/141450709-0a14be2c-061d-4e31-8b1c-ef0c47e2d909.png)

**After Fix**
![After](https://user-images.githubusercontent.com/44396182/141450736-e519bb0b-f6f2-4126-a668-4d7cd6082cfe.png)


- After updating the system to GNOME 41, the "utilities-system-monitor-symbolic" icon is no longer present, unless the user has installed a set of custom icons such as Tela. To solve the problem, instead of using that icon, the System Monitor icon is used, which will surely be installed to take advantage of the button's functionality.