### PR TITLE
Add minimum and maximum values in menu 

### DIFF
--- a/values.js
+++ b/values.js
@@ -248,15 +248,15 @@ var Values = GObject.registerClass({
             max = this._legible(max, format);
 
             output.push(['Average', avg, type, '__' + type + '_avg__']);
-            output.push([type, avg, type, '__' + type + '_avg__']);
+            output.push([type, avg, type + '-group', '']);
 
             // If only one value is present, don't display min and max
             if (vals.length > 1) {
                 output.push(['Minimum', min, type, '__' + type + '_min__']);
                 output.push(['Maximum', max, type, '__' + type + '_max__']);
 
-                output.push([type, min, type, '__' + type + '_min__']);
-                output.push([type, max, type, '__' + type + '_max__']);
+                output.push([type, min, type + '-group', '']);
+                output.push([type, max, type + '-group', '']);
             }
         } else if (type == 'network-rx' || type == 'network-tx') {
             let direction = type.split('-')[1];

--- a/values.js
+++ b/values.js
@@ -234,15 +234,30 @@ var Values = GObject.registerClass({
         let previousValue = this._history[type][key];
         this._history[type][key] = [legible, value];
 
-        // process average values
+        // process average, min and max values
         if (type == 'temperature' || type == 'voltage' || type == 'fan') {
             let vals = Object.values(this._history[type]).map(x => parseFloat(x[1]));
             let sum = vals.reduce((a, b) => a + b);
             let avg = sum / vals.length;
             avg = this._legible(avg, format);
 
+            let min = Math.min(...vals);
+            min = this._legible(min, format);
+
+            let max = Math.max(...vals);
+            max = this._legible(max, format);
+
             output.push(['Average', avg, type, '__' + type + '_avg__']);
-            output.push([type, avg, type + '-group', '']);
+            output.push([type, avg, type, '__' + type + '_avg__']);
+
+            // If only one value is present, don't display min and max
+            if (vals.length > 1) {
+                output.push(['Minimum', min, type, '__' + type + '_min__']);
+                output.push(['Maximum', max, type, '__' + type + '_max__']);
+
+                output.push([type, min, type, '__' + type + '_min__']);
+                output.push([type, max, type, '__' + type + '_max__']);
+            }
         } else if (type == 'network-rx' || type == 'network-tx') {
             let direction = type.split('-')[1];
 


### PR DESCRIPTION
This pull request adds minimum and maximum values in temperature, voltage, and fan menus. I have tried to make a setting, but disabling the setting requires a Gnome Shell restart (I think it's a bug in the setting handler, or something like that, because enabling the setting is working, my code is [there](https://github.com/Yaya-Cout/Vitals/tree/min-max-settings)). I decided to hide the min and max values when only one sensor is available, but I don't know if it's a good idea since sensors can be added or removed using `detect-sensors`. The second screenshot is a bit buggy, because I duplicated sensors in the source… It fixes #270.

![screenshot with only one sensor](https://user-images.githubusercontent.com/67095734/184329423-39125d9b-4dca-4f7b-a846-fa97b63696fa.png)
![screenshot with multiples sensors](https://user-images.githubusercontent.com/67095734/184329260-e67583e0-47d1-4512-89da-22ca948e26d0.png)