### PR TITLE
Two fixes for nvidia-smi handling

### DIFF
--- a/helpers/subprocess.js
+++ b/helpers/subprocess.js
@@ -36,14 +36,19 @@ SubProcess.prototype.read = function(delimiter = '') {
                 read_str = convertUint8ArrayToString(read_bytes);
 
                 // split read_str by delimiter if passed in
-                if (delimiter) read_str = read_str.split(delimiter);
+                if (delimiter) {
+                    if (read_str == '')
+                        read_str = []; // EOF, ''.split(delimiter) would return ['']
+                    else
+                        read_str = read_str.split(delimiter);
+                }
 
                 // return results
                 resolve(read_str);
             } catch (e) {
                 if (e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.PENDING)) {
                     // previous read attempt is still waiting for something from stdout
-                    // ignore second attempt, return empty data
+                    // ignore second attempt, return empty data (like EOF)
                     if (delimiter) resolve([]);
                     else resolve('');
                 } else {

--- a/sensors.js
+++ b/sensors.js
@@ -107,6 +107,8 @@ var Sensors = GObject.registerClass({
                 }
             }
         }
+
+        this._queryNvidiaSmi(callback);
     }
 
     _queryTempVoltFan(callback, type) {
@@ -119,8 +121,6 @@ var Sensors = GObject.registerClass({
                 this._returnValue(callback, label, 'disabled', type, sensor['format']);
             });
         }
-
-        this._queryNvidiaSmi(callback);
     }
 
     _queryNvidiaSmi(callback) {

--- a/sensors.js
+++ b/sensors.js
@@ -51,8 +51,9 @@ var Sensors = GObject.registerClass({
 
         this._last_processor = { 'core': {}, 'speed': [] };
 
-        this._settings.connect('changed::query-nvidia-smi', this._reconfigureNvidiaSmiProcess.bind(this));
-        this._settings.connect('changed::update-time', this._reconfigureNvidiaSmiProcess.bind(this));
+        this._settingChangedSignals = [];
+        this._addSettingChangedSignal('query-nvidia-smi', this._reconfigureNvidiaSmiProcess.bind(this));
+        this._addSettingChangedSignal('update-time', this._reconfigureNvidiaSmiProcess.bind(this));
 
         this._nvidia_smi_process = null;
         this._nvidia_labels = [];
@@ -65,6 +66,10 @@ var Sensors = GObject.registerClass({
             this._lastRead = 0;
             this._lastWrite = 0;
         }
+    }
+
+    _addSettingChangedSignal(key, callback) {
+        this._settingChangedSignals.push(this._settings.connect('changed::' + key, callback));
     }
 
     _refreshIPAddress(callback) {
@@ -771,5 +776,8 @@ var Sensors = GObject.registerClass({
 
     destroy() {
         this._terminateNvidiaSmiProcess();
+
+        for (let signal of Object.values(this._settingChangedSignals))
+            this._settings.disconnect(signal);
     }
 });


### PR DESCRIPTION
Hi!

These two commits should improve the state of things:
- Instead of calling the _queryNvidiaSmi method multiple times per query() from the _queryTempVoltFan() method, call it only once, from the query() method itself. Somehow I overlooked this when deciding where to put the call in my initial PR. This should not affect functionality.
- Fix EOF handling in the subprocess helper to hopefully solve a (in my testing) pretty rare race condition that could end with no nvidia-smi process being active, see commit message for details.

Also, I'm worried because my gnome-shell extensions gjs process consumed 80MB of RAM yesterday, so there might be some other issue. I haven't been able to reproduce this yet.