### PR TITLE
Allow the system monitor button to spawn a command composed of multiple words

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -143,7 +143,7 @@ var VitalsMenuButton = GObject.registerClass({
         let monitorButton = this._createRoundButton('org.gnome.SystemMonitor-symbolic', _('System Monitor'));
         monitorButton.connect('clicked', (self) => {
             this.menu._getTopMenu().close();
-            Util.spawn([this._settings.get_string('monitor-cmd')]);
+            Util.spawn(this._settings.get_string('monitor-cmd').split(" "));
         });
         customButtonBox.add_actor(monitorButton);
 


### PR DESCRIPTION
Hi!

I was unable to launch a terminal system monitor because the whole command was used as a whole. 

Currently, the following configuration fails: 

![imagen](https://user-images.githubusercontent.com/1476904/235444945-f9f4b6d0-94f9-4f60-ba00-94af7f7fef8e.png)

This pull request should fix this by splinting the string passed in the dialog by spaces and spawn the process from the generated array.
