### PR TITLE
Adding support for battery with key 'BATT'

### DIFF
--- a/prefs.ui
+++ b/prefs.ui
@@ -1222,6 +1222,7 @@
                           <item translatable="yes">BAT0</item>
                           <item translatable="yes">BAT1</item>
                           <item translatable="yes">BAT2</item>
+                          <item translatable="yes">BATT</item>
                           <item translatable="yes">CMB0</item>
                           <item translatable="yes">macsmc-battery</item>
                         </items>

--- a/sensors.js
+++ b/sensors.js
@@ -373,9 +373,11 @@ export const Sensors = GObject.registerClass({
         // addresses issue #161
         let battery_key = 'BAT'; // BAT0, BAT1 and BAT2
         if (battery_slot == 3) {
+            battery_slot = 'T';
+        } else if (battery_slot == 4) {
             battery_key = 'CMB'; // CMB0
             battery_slot = 0;
-        } else if (battery_slot == 4) {
+        } else if (battery_slot == 5) {
             battery_key = 'macsmc-battery'; // supports Asahi linux
             battery_slot = '';
         }


### PR DESCRIPTION
Hi!

Quick fix to add battery support for Asus zenbook UM3402YA. It should answer #405.

I saw that the batteries were mentioned in a translation file (locale/vitals.po), but I'm not familiar with this type of file, so I didn't make any changes.