### PR TITLE
Fix wrong unit of amd gpu memory reading

### DIFF
--- a/sensors.js
+++ b/sensors.js
@@ -638,6 +638,7 @@ export const Sensors = GObject.registerClass({
 
     _readGpuDrm(callback){
         const multiGpu = this._gpu_drm_indices.length > 1;
+        const unit = this._settings.get_int('memory-measurement') ? 1000 : 1024;
         for (let z = 0; z < this._gpu_drm_indices.length; z++ ) {
             let i = this._gpu_drm_indices[z];
             const typeName = 'gpu#' + i;
@@ -655,12 +656,12 @@ export const Sensors = GObject.registerClass({
                     // nothing to do, keep old value displayed
                 });
                 new FileModule.File('/sys/class/drm/card'+i+'/device/mem_info_vram_used').read().then(value => {
-                    this._returnGpuValue(callback, 'Memory Used', parseInt(value), typeName, 'memory');
+                    this._returnGpuValue(callback, 'Memory Used', parseInt(value) / unit, typeName, 'memory');
                 }).catch(err => {
                     // nothing to do, keep old value displayed
                 });
                 new FileModule.File('/sys/class/drm/card'+i+'/device/mem_info_vram_total').read().then(value => {
-                    this._returnGpuValue(callback, 'Memory Total', parseInt(value), typeName, 'memory');
+                    this._returnGpuValue(callback, 'Memory Total', parseInt(value) / unit, typeName, 'memory');
                 }).catch(err => {
                     // nothing to do, keep old value displayed
                 });


### PR DESCRIPTION
I tried the newly introduced amd gpu monitoring from https://github.com/corecoding/Vitals/pull/456 and noticed the displayed memory values are not correct. For my  RX 7800 XT this was displayed (with decimal setting)

![before-fix](https://github.com/user-attachments/assets/9a611eb2-356f-468b-8201-5af61db7f6d2)

17TB would not be bad but sadly this card only has 16GB of memory 😉 With this change the reporting will show the following

**decimal**
![after-fix-decimal](https://github.com/user-attachments/assets/87e0872c-08dc-4d38-b6b1-0543b09272ff)

**binary**
![after-fix-binary](https://github.com/user-attachments/assets/e8ac7c47-a5eb-495c-ba23-202717a7505f)

Grabbing the memory-measurment setting is not optimal but needs to be done for correct unit calculation. Best would be to pass the unit of the measurement with the reading but this would be a bigger rework.