### PR TITLE
Add maximum CPU frequency

### DIFF
--- a/sensors.js
+++ b/sensors.js
@@ -230,16 +230,20 @@ export const Sensors = GObject.registerClass({
                 let hertz = (sum / freqs.length) * 1000 * 1000;
                 this._returnValue(callback, 'Frequency', hertz, 'processor', 'hertz');
 
-                //let max_hertz = Math.getMaxOfArray(freqs) * 1000 * 1000;
-                //this._returnValue(callback, 'Boost', max_hertz, 'processor', 'hertz');
+                let max_hertz = freqs.reduce((a, b) => Math.max(a, b)) * 1000 * 1000;
+                this._returnValue(callback, 'Max frequency', max_hertz, 'processor', 'hertz');
+                let min_hertz = freqs.reduce((a, b) => Math.min(a, b)) * 1000 * 1000;
+                this._returnValue(callback, 'Min frequency', min_hertz, 'processor', 'hertz');
             }).catch(err => { });
         // if frequency scaling is enabled, cpu-freq reports
         } else if (Object.values(this._last_processor['speed']).length > 0) {
             let sum = this._last_processor['speed'].reduce((a, b) => a + b);
             let hertz = (sum / this._last_processor['speed'].length) * 1000;
             this._returnValue(callback, 'Frequency', hertz, 'processor', 'hertz');
-            //let max_hertz = Math.getMaxOfArray(this._last_processor['speed']) * 1000;
-            //this._returnValue(callback, 'Boost', max_hertz, 'processor', 'hertz');
+            let max_hertz = this._last_processor['speed'].reduce((a, b) => Math.max(a, b)) * 1000;
+            this._returnValue(callback, 'Max frequency', max_hertz, 'processor', 'hertz');
+            let min_hertz = this._last_processor['speed'].reduce((a, b) => Math.min(a, b)) * 1000;
+            this._returnValue(callback, 'Min frequency', min_hertz, 'processor', 'hertz');
         }
     }
 


### PR DESCRIPTION
Add stats for maximum and minimum core frequency. 

It used to be there but got commented out at some point without explanation. At least on my system `Math.getMaxOfArray` does not exist maybe that's why it got removed.

After using this for a week it turned out to be less useful than I hoped, but still better than seeing just the average. 

Not calling it boost since that gives the word more meaning than how it's actually obtained. Boost is often used to describe the cpu feature of temporary increasing frequency above the nominal value. For me it would feel weird calling something a boost frequency when all the cores have been down clocked significantly lower than nominal value due to power saving or thermal throttling reasons. Maximum isn't perfect either as that can be confused with maximum configured/theoretical value, but trying to clarify it would probably make it excessively verbose. 

Following is just my observations and rambling about it being difficult to visualize frequency of modern multicore systems in a way that's meaningful and easy to read. I don't have any good suggestions.

On my desktop zen3 system most of the time, while I am not running a compilation job, one or few cores are boosting at max frequency all the time, half the idles cores  being kept at minimum and a few more  at base clock (probably due to limitations in granularity or speed of frequency changes). 
Here is a specific example: 1x 4.7GHz  13x3.5GHz  18x1.7GHz => Avg: 2.5GHz, Max: 4.7GHz, Min 1.7GHz. 
Having 2 or 3 busy cores running at maximum boost frequency instead of 1 would barely affect the average.

This means that average is a random number which sometimes vaguely correlates with overall system load level like a bad version of loadavg or CPU usage %, but doesn't actually correspond to anything close to the value use by any of cores.  But a lot of time it's more influenced by speed and granularity of frequency downscaling and fraction of cores idling at nominal frequency compared compared cores at minimum .  Max and minimum and such situations tell more about the overall system capabilities/configuration than the current state. 
 
With  a couple of cores loaded maximum becomes slightly more useful  as it then somewhat correspond to boost capabilities based on current load and cooling.
 
At maximum 100% system load all 3 numbers become  equal (above idle average and below idle max boost). In this case average frequency is somewhat useful number.  There are minor core to core variance but you would need to print 5 or more digits to notice them. I am not even sure how much of it is core to core variance and how much it's a side effect of reading core frequencies one by one as they change over time.

Situation somewhat remind the examples in introductions statistics classes demonstrating that arithmetic mean isn't always useful. Just in this case outliers are the interesting values instead of majority.  The basic approaches of using mode or median wouldn't help in this case as both of them would just display minimum frequency, which by itself is worse than the average. 

An interesting observation is that at idle state, max value I see reported by this plugin is consistently higher than what I could observe `cat /sys/devices/system/cpu/cpu*/cpufreq/scaling_cur_freq | sort` reports. Widget typically displays maximum at ~4.6-4.8GHz but with cat it's hard to get get above 4.2. When there is any real load this isn't much of a problem.   I am guessing that unlike  previously claimed single core isn't being constantly boosted to max frequency, the system just boosts it during update to finish the job as fast as possible so that it can sooner return to lower power mode.  The overall load from all the UI updates scheduled at the same time is probably enough to trigger the frequency boost, but running cat isn't.  On one hand it might make the cpu look more active than it is on average, on the other displaying the maximum frequency of when the CPU is doing actual work instead of sleeping might be more useful.  This would more problematic for attempts to calculate average power consumption based instantaneous readings.  

Just displaying all the raw frequencies even in graphic way without additional transformation isn't particularly useful either. The scheduler keeps moving the active processes around and  frequency is jumping accordingly many times per second so all you see is noise.

That's just my system on  different systems using different frequency scaling strategy the results and usefulness of avg/max/min reading would differ.