### PR TITLE
Fix for Gnome 49

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,7 @@
   "name": "Vitals",
   "settings-schema": "org.gnome.shell.extensions.vitals",
   "shell-version": [
-    "45", "46", "47", "48"
+    "45", "46", "47", "48", "49"
   ],
   "url": "https://github.com/corecoding/Vitals",
   "uuid": "Vitals@CoreCoding.com",


### PR DESCRIPTION
Update metadata.json

GNOME 49 support, tested on Arch-Linux