### PR TITLE
Fix/panel icon padding

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -296,6 +296,12 @@ var VitalsMenuButton = GObject.registerClass({
 
             const className = index === 0 ? 'vitals-panel-icon-leftmost' : 'vitals-panel-icon-intermediate';
             icon.add_style_class_name(className);
+            
+            if(this._settings.get_boolean('hide-icons')) {
+                icon.set_style('margin-right: 0;');
+            } else {
+                icon.set_style('null');
+            }
         });
     }
 

--- a/extension.js
+++ b/extension.js
@@ -291,10 +291,10 @@ var VitalsMenuButton = GObject.registerClass({
             
             const icon = this._hotIcons[key];
         
-            icon.remove_style_class_name('vitals-panel-icon-initial');
+            icon.remove_style_class_name('vitals-panel-icon-leftmost');
             icon.remove_style_class_name('vitals-panel-icon-intermediate');
 
-            const className = index === 0 ? 'vitals-panel-icon-initial' : 'vitals-panel-icon-intermediate';
+            const className = index === 0 ? 'vitals-panel-icon-leftmost' : 'vitals-panel-icon-intermediate';
             icon.add_style_class_name(className);
         });
     }

--- a/extension.js
+++ b/extension.js
@@ -360,17 +360,19 @@ var VitalsMenuButton = GObject.registerClass({
             this._removeHotLabel(key);
     }
 
-    _removeHotIcon(key) {
+    _removeHotIcon(key, updateMargins = true) {
         if (key in this._hotIcons) {
             this._hotIcons[key].destroy();
             delete this._hotIcons[key];
-            this._updateHotIconMargins();
+            if (updateMargins) { 
+                this._updateHotIconMargins(); 
+            }    
         }
     }
 
     _removeHotIcons() {
         for (let key in this._hotIcons)
-            this._removeHotIcon(key);
+            this._removeHotIcon(key, false);
     }
 
     _redrawMenu() {

--- a/extension.js
+++ b/extension.js
@@ -280,7 +280,7 @@ var VitalsMenuButton = GObject.registerClass({
         this._menuLayout.add_child(label);
 
         // support for fixed widths #55, save label (text) width
-        this._widths[key] = label.width;
+        this._widths[key] = label.get_clutter_text().width;
     }
 
     _updateHotIconMargins() {

--- a/extension.js
+++ b/extension.js
@@ -258,6 +258,7 @@ var VitalsMenuButton = GObject.registerClass({
         let icon = this._defaultIcon(key);
         this._hotIcons[key] = icon;
         this._menuLayout.add_child(icon)
+        this._updateHotIconMargins();
 
         // don't add a label when no sensors are in the panel
         if (key == '_default_icon_') return;
@@ -280,6 +281,22 @@ var VitalsMenuButton = GObject.registerClass({
 
         // support for fixed widths #55, save label (text) width
         this._widths[key] = label.width;
+    }
+
+    _updateHotIconMargins() {
+        const iconKeys = Object.keys(this._hotIcons);
+        
+        iconKeys.forEach((key, index) => {
+            if (key === '_default_icon_') return; 
+            
+            const icon = this._hotIcons[key];
+        
+            icon.remove_style_class_name('vitals-panel-icon-initial');
+            icon.remove_style_class_name('vitals-panel-icon-intermediate');
+
+            const className = index === 0 ? 'vitals-panel-icon-initial' : 'vitals-panel-icon-intermediate';
+            icon.add_style_class_name(className);
+        });
     }
 
     _showHideSensorsChanged(self, sensor) {
@@ -347,6 +364,7 @@ var VitalsMenuButton = GObject.registerClass({
         if (key in this._hotIcons) {
             this._hotIcons[key].destroy();
             delete this._hotIcons[key];
+            this._updateHotIconMargins();
         }
     }
 

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -1,5 +1,7 @@
 .vitals-icon { icon-size: 16px; }
 .vitals-menu-button-container {}
+.vitals-panel-icon-initial { margin-left: 3px !important; }
+.vitals-panel-icon-intermediate { margin-left: 8px !important; }
 .vitals-panel-icon-temperature { margin: 0 1px 0 8px; padding: 0; }
 .vitals-panel-icon-voltage { margin: 0 0 0 8px; padding: 0; }
 .vitals-panel-icon-fan { margin: 0 4px 0 8px; padding: 0; }

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -1,17 +1,17 @@
 .vitals-icon { icon-size: 16px; }
 .vitals-menu-button-container {}
-.vitals-panel-icon-initial { margin-left: 3px !important; }
-.vitals-panel-icon-intermediate { margin-left: 8px !important; }
-.vitals-panel-icon-temperature { margin: 0 1px 0 8px; padding: 0; }
-.vitals-panel-icon-voltage { margin: 0 0 0 8px; padding: 0; }
-.vitals-panel-icon-fan { margin: 0 4px 0 8px; padding: 0; }
-.vitals-panel-icon-memory { margin: 0 2px 0 8px; padding: 0; }
-.vitals-panel-icon-processor { margin: 0 3px 0 8px; padding: 0; }
-.vitals-panel-icon-system { margin: 0 3px 0 8px; padding: 0; }
-.vitals-panel-icon-network { margin: 0 3px 0 8px; padding: 0; }
-.vitals-panel-icon-storage { margin: 0 2px 0 8px; padding: 0; }
-.vitals-panel-icon-battery { margin: 0 4px 0 8px; padding: 0; }
-.vitals-panel-label { margin: 0 3px 0 0; padding: 0; }
+.vitals-panel-icon-leftmost { margin-left: 3px; }
+.vitals-panel-icon-intermediate { margin-left: 8px; }
+.vitals-panel-icon-temperature { margin-right: 1px; padding: 0; }
+.vitals-panel-icon-voltage { margin-right: 0; padding: 0; }
+.vitals-panel-icon-fan { margin-right: 4px; padding: 0; }
+.vitals-panel-icon-memory { margin-right: 2px; padding: 0; }
+.vitals-panel-icon-processor { margin-right: 3px; padding: 0; }
+.vitals-panel-icon-system { margin-right: 3px; padding: 0; }
+.vitals-panel-icon-network { margin-right: 3px; padding: 0; }
+.vitals-panel-icon-storage { margin-right: 2px; padding: 0; }
+.vitals-panel-icon-battery { margin-right: 4px; padding: 0; }
+.vitals-panel-label { margin-right: 3px; padding: 0; }
 .vitals-button-action { -st-icon-style: symbolic; border-radius: 32px; margin: 0px; min-height: 22px; min-width: 22px; padding: 10px; font-size: 100%; border: 1px solid transparent; }
 .vitals-button-action:hover, .vitals-button-action:focus { border-color: #777; }
 .vitals-button-action > StIcon { icon-size: 16px; }


### PR DESCRIPTION
# Fix: Panel Icon Padding Issues

## Summary
This PR addresses the uneven margins on the side of the panel button. The issue occurs due to how style classes are applied and elements are ordered, resulting in inconsistent spacing on both ends of the panel.

## Current problem

```
8px [ICON] VAR: px + 0px [LABEL] 3px + 8 px [ICON] VAR px + 0px [LABEL] 3px
 ↑                                                                       ↑
```

**Note**: VAR depend on the exact icon type and is hardcoded in the style classes.

`hide-icons` only hides the icon glyph and does not remove the custom styled StIcon itself, so it has the same problem. With the additional icon dependent contribution

```
8px [] VAR px + 0px [LABEL] 3px + 8 px [] VAR px + 0px [LABEL] 3px
 ↑      ↑                                  ↑                    ↑  
```


## Changes Made
- **Improved symmetry:** Aligned the first icon margin with the label's right margin
- **Fixed unwanted margins:** When hide-icons is enabled, icon right margins are now set to zero. 
- **Minor startup fix:** Fixed a "called on [...] not in the stage" error during initialization

## Technical Details
- **New margin system:** Implemented `_updateHotIconMargins()` function called during `_createHotMenuIcons()` and `_removeHotMenuIcons()` that dynamically applies CSS classes based on icon position.

- **Hide icons fix**: During `_updateHotIconMargins()` sets all icon right margins to zero, if `hide-icons` is enabled  using `set_style`

- **New CSS classes:** Added .`vitals-panel-icon-leftmost` and `.vitals-panel-icon-intermediate` style classes

- **CSS changes**: Adapted existing `.vitals-panel-icon-*` classes to eliminate reliance on `!important` in the new CSS classes. Those classes now only set the padding to zero and the right margin. Top and bottom margins are inherited as zero from the base class `system-status-icon`. Left margin gets handled by the new function and the new classes.

- Added conditional update parameter to `_removeHotMenuIcon` to reduce unnecessary margin updates during `_redrawMenu >_removeHotMenuIcons`

- **Startup error fix:** Changed `.width` to `.get_clutter_text().width` in  `_createHotMenuIcons` to prevent an error/warning during startup. Consistent with the fixed width logic in `_updateDisplay`


## Testing
1.  Verified no startup errors occur, nor any errors during adding and removal of HotIcons and setting changes. 
2. Confirmed icon alignment is visually consistent with and without icons, and with and without fixed width.
3. Tested on Fedora 42 with Gnome 48 
 

## Screenshots/Visual Changes
**Before and after with icons:**
<img width="1063" height="372" alt="with_icons" src="https://github.com/user-attachments/assets/fcf890c2-0364-4180-91fa-9ae6b18c8410" />

**Before and after without icons:**
<img width="887" height="371" alt="without_icons" src="https://github.com/user-attachments/assets/2885543a-8b78-4e8c-ad9d-4f34f38db8e5" />


## P.S. 
This is my first time interacting with javascript/gnome-extensions and contributing to a project. So sorry in advance for any fumbles.