### PR TITLE
Add GTT memory monitoring for AMD GPUs

### DIFF
--- a/sensors.js
+++ b/sensors.js
@@ -665,6 +665,19 @@ export const Sensors = GObject.registerClass({
                 }).catch(err => {
                     // nothing to do, keep old value displayed
                 });
+                // GTT (Graphics Translation Table) memory - system RAM accessible by the GPU.
+                // Particularly useful for AMD APUs (e.g. Strix Halo, Rembrandt, Phoenix)
+                // where GTT memory can be significantly larger than dedicated VRAM.
+                new FileModule.File('/sys/class/drm/card'+i+'/device/mem_info_gtt_used').read().then(value => {
+                    this._returnGpuValue(callback, 'GTT Used', parseInt(value) / unit, typeName, 'memory');
+                }).catch(err => {
+                    // not all AMD GPUs expose GTT info, silently ignore
+                });
+                new FileModule.File('/sys/class/drm/card'+i+'/device/mem_info_gtt_total').read().then(value => {
+                    this._returnGpuValue(callback, 'GTT Total', parseInt(value) / unit, typeName, 'memory');
+                }).catch(err => {
+                    // not all AMD GPUs expose GTT info, silently ignore
+                });
             } else {
                 // for other vendors only show basic card info
                 let vendorName = null;


### PR DESCRIPTION
## Summary

- Adds **GTT (Graphics Translation Table) memory** monitoring for AMD GPUs detected via DRM sysfs
- Reads `mem_info_gtt_used` and `mem_info_gtt_total` from `/sys/class/drm/cardN/device/` and exposes them as two new GPU sensor fields: **GTT Used** and **GTT Total**
- Errors are silently caught so discrete AMD GPUs or older drivers that don't expose these files are unaffected

## Motivation

GTT memory represents **system RAM accessible by the GPU**. On AMD APUs — such as Strix Halo (Ryzen AI MAX), Rembrandt, and Phoenix — the dedicated VRAM is typically very small (e.g. 512 MiB), while GTT can be **tens to hundreds of GiBs** of system memory allocated to the GPU.

For workloads like LLM inference (via ROCm/llama.cpp), the GPU primarily uses GTT memory rather than VRAM. Tools like `amdgpu_top` already report GTT usage, but Vitals currently only shows VRAM — which gives an incomplete picture on these APUs.

### Example on an AMD Ryzen AI MAX+ 395 (Strix Halo):
| Memory Type | Total | Typical Usage |
|---|---|---|
| VRAM (dedicated) | 512 MiB | ~455 MiB |
| **GTT (system RAM)** | **124 GiB** | **~63 GiB** (running LLMs) |

Without GTT monitoring, Vitals only shows the 512 MiB VRAM, missing the 63 GiB actually being used by the GPU.

## Changes

- **`sensors.js`**: Added two new `FileModule.File` reads inside the existing AMD DRM block in `_readGpuDrm()`, reading `mem_info_gtt_used` and `mem_info_gtt_total`. Both are wrapped in `.catch()` blocks to gracefully handle systems where these files don't exist.

## Testing

- Tested on Fedora 43 with AMD Ryzen AI MAX+ 395 (Strix Halo) / Radeon 8060S
- GTT values correctly displayed alongside existing VRAM values
- Verified that the extension loads without errors on systems where GTT sysfs files are present
- No regressions observed for existing GPU, temperature, or other sensor readings

Made with [Cursor](https://cursor.com)