### PR TITLE
Fix DRM GPU index mapping for UI groups

### DIFF
--- a/sensors.js
+++ b/sensors.js
@@ -641,7 +641,8 @@ export const Sensors = GObject.registerClass({
         const unit = this._settings.get_int('memory-measurement') ? 1000 : 1024;
         for (let z = 0; z < this._gpu_drm_indices.length; z++ ) {
             let i = this._gpu_drm_indices[z];
-            const typeName = 'gpu#' + i;
+            const gpuIndex = z + 1;
+            const typeName = 'gpu#' + gpuIndex;
             const vendor = this._gpu_drm_vendors[z];
 
             // AMD


### PR DESCRIPTION
Issue: On some systems with non-contiguous DRM card indices, GPU data is reported as gpu#0 while the UI only creates groups gpu#1..N, so the Graphics tab shows No Data. Fix: map detected DRM cards to sequential gpu#1..N for UI types while still using the real DRM card index for file paths.

Note: On my AMD integrated GPU, Vitals detected the card but showed “No Data” in the Graphics tab. The data was being reported under gpu#0, but the UI only created GPU groups starting at gpu#1, so the updates never reached the visible group. This patch maps detected DRM cards to sequential gpu#1..N for UI display while still using the real DRM index for file paths.

Tested on:
OS: Debian GNU/Linux 13 (trixie) x86_64
Kernel: Linux 6.12.69+deb13-amd64
GNOME 48.7 Wayland
GPU: AMD Radeon 840M / 860M (Integrated)