### PR TITLE
Add support to drivetemp kernel module

### DIFF
--- a/sensors.js
+++ b/sensors.js
@@ -908,7 +908,8 @@ export const Sensors = GObject.registerClass({
                                 trisensors[key2] = {
                                     'type': sensor_types[sensor_type],
                                   'format': sensor_type,
-                                   'label': path + '/name'
+                                   // if name = 'drivetemp' I put the drive model
+                                   'label': path + (name == 'drivetemp' ? '/device/model' : '/name')
                                 };
                             }
 
@@ -941,8 +942,8 @@ export const Sensors = GObject.registerClass({
     }
 
     _addTempVoltFan(callback, obj, name, label, extra, value) {
-        // prepend module that provided sensor data
-        if (name != label) label = name + ' ' + label;
+        // prepend module that provided sensor data (I don't do this for drivetemp)
+        if (name != label && name != "drivetemp") label = name + ' ' + label;
 
         //if (label == 'nvme Composite') label = 'NVMe';
         //if (label == 'nouveau') label = 'Nvidia';


### PR DESCRIPTION
I added support for the `drivetemp` kernel module, which allows retrieving HDD temperature data.
When the module generating the sensor data is `drivetemp`, I do not add it to the label; otherwise, the label would show “drivetemp model extra”, which looks bad in the UI.
I'm not entirely sure if this is the best way to implement the changes, so feedback is welcome.

Result:
<img width="294" height="161" alt="image" src="https://github.com/user-attachments/assets/97addae2-cc6f-4275-8434-dce3d7bf1127" />
