### PR TITLE
Add Gnome 50 to supported shell versions

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,7 @@
   "name": "Vitals",
   "settings-schema": "org.gnome.shell.extensions.vitals",
   "shell-version": [
-    "45", "46", "47", "48", "49"
+    "45", "46", "47", "48", "49", "50"
   ],
   "url": "https://github.com/corecoding/Vitals",
   "uuid": "Vitals@CoreCoding.com",


### PR DESCRIPTION
Add Gnome 50 as a supported version to the metadata file. Works fine for me so far on Fedora 44 Beta