### PR TITLE
fix: remove redundant cache load and avoid GSettings lookup on every tick

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -69,9 +69,6 @@ var VitalsMenuButton = GObject.registerClass({
         this._historyCachePath = GLib.get_user_cache_dir() + '/vitals/history.json';
         this._timeSeriesLoaded = false;
 
-        if (this._settings.get_boolean('show-sensor-history-graph'))
-            this._values.loadTimeSeries(this._historyCachePath);
-
         this._menuLayout = new St.BoxLayout({
             vertical: false,
             clip_to_allocation: true,
@@ -95,8 +92,12 @@ var VitalsMenuButton = GObject.registerClass({
             if (!this._settings.get_boolean('show-sensor-history-graph')) {
                 this._hideHistoryPopout();
                 this._values.clearTimeSeries(this._historyCachePath);
+                this._values._recordTimeSeries = false;
+                this._timeSeriesLoaded = false;
             } else {
                 this._values.loadTimeSeries(this._historyCachePath);
+                this._values._recordTimeSeries = true;
+                this._timeSeriesLoaded = true;
             }
         });
 
@@ -319,42 +320,40 @@ var VitalsMenuButton = GObject.registerClass({
         }
     }
 
+    _ensureTimeSeriesLoaded() {
+        if (this._timeSeriesLoaded) return;
+        const memSeries = {};
+        const memFormat = {};
+        for (const k in this._values._timeSeries)
+            memSeries[k] = this._values._timeSeries[k].slice();
+        for (const k in this._values._timeSeriesFormat)
+            memFormat[k] = this._values._timeSeriesFormat[k];
+
+        this._values.loadTimeSeries(this._historyCachePath);
+
+        for (const k in memSeries) {
+            if (!(k in this._values._timeSeries)) {
+                this._values._timeSeries[k] = memSeries[k];
+            } else {
+                const cached = this._values._timeSeries[k];
+                const mem = memSeries[k];
+                const lastCacheT = cached.length > 0 ? cached[cached.length - 1].t : 0;
+                for (let i = 0; i < mem.length; i++) {
+                    if (mem[i].t > lastCacheT)
+                        cached.push(mem[i]);
+                }
+                this._values._timeSeries[k] = cached;
+            }
+            if (k in memFormat)
+                this._values._timeSeriesFormat[k] = memFormat[k];
+        }
+
+        this._timeSeriesLoaded = true;
+    }
+
     _showHistoryPopout(key, label, itemActor) {
         if (!this._settings.get_boolean('show-sensor-history-graph')) return;
-        // lazy-load persisted time series on first popout open, merging with in-memory data
-        if (!this._timeSeriesLoaded) {
-            // save current in-memory data before loading cache
-            const memSeries = {};
-            const memFormat = {};
-            for (const k in this._values._timeSeries)
-                memSeries[k] = this._values._timeSeries[k].slice();
-            for (const k in this._values._timeSeriesFormat)
-                memFormat[k] = this._values._timeSeriesFormat[k];
-
-            this._values.loadTimeSeries(this._historyCachePath);
-
-            // merge: use cache as prefix, append newer in-memory entries
-            for (const k in memSeries) {
-                if (!(k in this._values._timeSeries)) {
-                    this._values._timeSeries[k] = memSeries[k];
-                } else {
-                    const cached = this._values._timeSeries[k];
-                    const mem = memSeries[k];
-                    const lastCacheT = cached.length > 0 ? cached[cached.length - 1].t : 0;
-                    // append in-memory points newer than last cache entry
-                    for (let i = 0; i < mem.length; i++) {
-                        if (mem[i].t > lastCacheT)
-                            cached.push(mem[i]);
-                    }
-                    this._values._timeSeries[k] = cached;
-                }
-                // preserve format from in-memory if available
-                if (k in memFormat)
-                    this._values._timeSeriesFormat[k] = memFormat[k];
-            }
-
-            this._timeSeriesLoaded = true;
-        }
+        this._ensureTimeSeriesLoaded();
         const samples = this._values.getTimeSeries(key);
         if (samples.length === 0) return;
         this._historyPopoutSensorKey = key;
@@ -921,8 +920,10 @@ var VitalsMenuButton = GObject.registerClass({
             this._historyPopout = null;
         }
         this._destroyTimer();
-        if (this._settings.get_boolean('show-sensor-history-graph'))
+        if (this._settings.get_boolean('show-sensor-history-graph')) {
+            this._ensureTimeSeriesLoaded();
             this._values.saveTimeSeries(this._historyCachePath);
+        }
         this._sensors.destroy();
 
         for (let signal of Object.values(this._settingChangedSignals))

--- a/values.js
+++ b/values.js
@@ -43,6 +43,7 @@ export const Values = GObject.registerClass({
     _init(settings, sensorIcons) {
         this._settings = settings;
         this._sensorIcons = sensorIcons;
+        this._recordTimeSeries = settings.get_boolean('show-sensor-history-graph');
 
         this._networkSpeedOffset = {};
         this._networkSpeeds = {};
@@ -62,7 +63,7 @@ export const Values = GObject.registerClass({
     }
 
     _pushTimePoint(key, value, format) {
-        if (!this._settings.get_boolean('show-sensor-history-graph')) return;
+        if (!this._recordTimeSeries) return;
         if (!this._graphableFormats.includes(format)) return;
         const num = typeof value === 'number' ? value : parseFloat(value);
         if (num !== num) return; // NaN check


### PR DESCRIPTION
Hey @corecoding, here's the follow-up with the two items from my comment.

## Summary

- Extract `_ensureTimeSeriesLoaded()` to deduplicate the cache load + merge
  logic (now used on first hover and on disable — prevents overwriting
  persisted history when the user never opened the popout)
- Remove redundant `loadTimeSeries()` from `_init()` — the lazy-load
  handles it with proper merge
- Cache `show-sensor-history-graph` in a `_recordTimeSeries` flag instead
  of calling `get_boolean()` on every sensor tick (6 calls/sec with
  default settings)
- Keep `_recordTimeSeries` and `_timeSeriesLoaded` in sync when toggling
  the setting on/off

## Changes

**extension.js:**
- New `_ensureTimeSeriesLoaded()` method (extracted from `_showHistoryPopout`)
- `_showHistoryPopout()` calls `_ensureTimeSeriesLoaded()` instead of inline merge
- `disable()` calls `_ensureTimeSeriesLoaded()` before saving
- Signal handler updates `_recordTimeSeries` and `_timeSeriesLoaded` on toggle
- Remove `loadTimeSeries()` from `_init()`

**values.js:**
- Add `_recordTimeSeries` flag initialized from settings in `_init()`
- `_pushTimePoint()` checks cached flag instead of `get_boolean()`

## Test plan

- [ ] Enable graph, collect data, hover sensor — graph shows correctly
- [ ] Enable graph, collect data, disable extension without hovering — re-enable and check history is preserved
- [ ] Toggle graph off/on via settings, verify data recording stops/resumes
- [ ] Monitor with `pidstat` — no GSettings overhead on every tick