### PR TITLE
Fix negative exponent for sub Hz frequency value

### DIFF
--- a/values.js
+++ b/values.js
@@ -97,7 +97,7 @@ export const Values = GObject.registerClass({
                 break;
             case 'hertz':
                 if (value > 0) {
-                    exp = Math.floor(Math.log(value) / Math.log(unit));
+                    exp = Math.max(0, Math.floor(Math.log(value) / Math.log(unit)));
                     if (value >= Math.pow(unit, exp) * (unit - 0.05)) exp++;
                     value = parseFloat((value / Math.pow(unit, exp)));
                 }


### PR DESCRIPTION
## Summary

When the refresh rate drops below 1 Hz, the exponent calculation can produce -1:

Math.floor(Math.log(value) / Math.log(unit))

Since the frequency unit array starts at Hz and does not contain negative indices, this results in an undefined unit lookup.

This change clamps the exponent to a minimum value of 0:

Math.max(0, Math.floor(Math.log(value) / Math.log(unit)))

This prevents invalid array access while preserving existing behavior for Hz, KHz, MHz, and GHz values.

## Testing

- Verified normal frequency formatting.
- Verified GHz values are unaffected.
- Verified values below 1 Hz no longer produce undefined units.

Fix for Issue: #555 