### PR TITLE
fix: Make _redrawMenu() append/pop hot items according to sensor pref…

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -356,6 +356,15 @@ var VitalsMenuButton = GObject.registerClass({
 
         for (let sensor in this._sensorIcons)
             this._settings.connectObject('changed::show-' + sensor, this._showHideSensorsChanged.bind(this), this);
+
+        // process sensor group toggles
+        let sensorGroups = [ 'show-temperature', 'show-voltage', 'show-fan',
+                        'show-memory', 'show-processor', 'show-system',
+                        'show-network', 'show-storage', 'show-battery',
+                        'show-gpu'];
+
+        for (let group of sensorGroups)
+            this._settings.connectObject('changed::' + group, this._redrawMenu.bind(this), this);
     }
 
     _initializeMenu() {
@@ -623,6 +632,20 @@ var VitalsMenuButton = GObject.registerClass({
         this._querySensors();
     }
 
+    // Map hotItem (top bar element) to sensor group
+    _getSensorGroupFromKey(key) {
+        if (key.includes("temperature")) return "temperature";
+        if (key.includes("voltage")) return "voltage";
+        if (key.includes("fan")) return "fan";
+        if (key.includes("memory")) return "memory";
+        if (key.includes("processor")) return "processor";
+        if (key.includes("system")) return "system";
+        if (key.includes("network")) return "network";
+        if (key.includes("storage")) return "storage";
+        if (key.includes("battery")) return "battery";
+        if (key.includes("gpu")) return "gpu";
+    }
+
     _drawMenu() {
         // grab list of selected menubar icons
         let hotSensors = this._settings.get_strv('hot-sensors');
@@ -631,7 +654,18 @@ var VitalsMenuButton = GObject.registerClass({
             if (key == '__max_network-download__') key = '__network-rx_max__';
             if (key == '__max_network-upload__') key = '__network-tx_max__';
 
-            this._createHotItem(key);
+            let sensorGroup = this._getSensorGroupFromKey(key);
+            if (sensorGroup) {
+                let isEnabled = this._settings.get_boolean("show-" + sensorGroup);
+
+                if (!isEnabled) {
+                    this._removeHotItem(key);
+                }
+
+                if (isEnabled) {
+                    this._createHotItem(key);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Problem:
When you disable a sensor such as 'Monitor Memory' in the extension preferences when you have a top bar icon showing that metric (hot item); the hot item will stay in the top bar with no way to remove it. The only way to remove it is to re-enable the sensor and then toggle off the hot item. 

Example:
<img width="668" height="432" alt="Screenshot From 2026-07-10 19-28-36" src="https://github.com/user-attachments/assets/a1365238-9993-47c8-b06c-b329edde7485" />

Solution:
I added logic to the '_redrawMenu()' method to check if a sensor group is enabled and update the array of hot sensors accordingly. I also added a gsettings signal to call _redrawMenu() every time a sensor group setting is toggled. Now, when a sensor group like "Monitor Memory" is disabled, the selected hot item will also disappear.

Example:
<img width="1393" height="581" alt="Screenshot From 2026-07-10 19-34-10" src="https://github.com/user-attachments/assets/2ed9ff26-8e7f-4788-9611-ef3c0ff8bafd" />
