### PR TITLE
Update default system monitor command to 'resources'

### DIFF
--- a/prefs.ui
+++ b/prefs.ui
@@ -1406,7 +1406,7 @@
                     </child>
                     <child>
                       <object class="GtkEntry" id="monitor-cmd">
-                        <property name="placeholder_text" translatable="no">gnome-system-monitor</property>
+                        <property name="placeholder_text" translatable="no">resources</property>
                         <property name="can_focus">1</property>
                         <property name="editable">1</property>
                         <property name="width_chars">24</property>

--- a/schemas/org.gnome.shell.extensions.vitals.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.vitals.gschema.xml
@@ -145,7 +145,7 @@
       <description>Center the menu to the icon regardless of the position in the panel</description>
     </key>
     <key type="s" name="monitor-cmd">
-      <default>"gnome-system-monitor"</default>
+      <default>"resources"</default>
       <summary>System Monitor command</summary>
       <description>The command run when system monitor button is clicked</description>
     </key>


### PR DESCRIPTION
Ubuntu 26.04 and newer versions have replaced 'gnome-system-monitor' with the new 'Resources' application. This change updates the default command to 'resources' to better support modern GNOME environments while remaining configurable for users who still prefer the legacy tool.