### PR TITLE
fix(panel): give GPU icons the same CSS styling as other sensors

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -792,8 +792,11 @@ var VitalsMenuButton = GObject.registerClass({
         let split = key.replaceAll('_', ' ').trim().split(' ')[0].split('-');
         let type = split[0];
 
+        // gpus are numbered (gpu#1, gpu#2, ...); share one css class like _sensorIconPath does
+        let styleClass = type.startsWith('gpu') ? 'gpu' : type;
+
         let icon = new St.Icon({
-          style_class: 'system-status-icon vitals-panel-icon-' + type,
+          style_class: 'system-status-icon vitals-panel-icon-' + styleClass,
             reactive: true
         });
 

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -12,6 +12,7 @@
 .vitals-panel-icon-network { margin: 0 3px 0 0; padding: 0; }
 .vitals-panel-icon-storage { margin: 0 2px 0 0; padding: 0; }
 .vitals-panel-icon-battery { margin: 0 4px 0 0; padding: 0; }
+.vitals-panel-icon-gpu { margin: 0 3px 0 0; padding: 0; }
 .vitals-panel-label {}
 .vitals-button-action { -st-icon-style: symbolic; border-radius: 32px; margin: 0px; min-height: 22px; min-width: 22px; padding: 10px; font-size: 100%; border: 1px solid transparent; }
 .vitals-button-action:hover, .vitals-button-action:focus { border-color: #777; }


### PR DESCRIPTION
## What
Fixes #565: in the top bar, the GPU icon's value text was shifted ~8px to the right of every other sensor's, and the icon itself rendered visually out of line.

Root cause: hot-sensor keys for GPUs are numbered (`_gpu#1_utilization_`, `_gpu#2_...`), so `_defaultIcon()` built the style class `vitals-panel-icon-gpu#1`. That class contains a `#` and cannot match any CSS rule, so the GPU icon was the only panel icon without a `.vitals-panel-icon-*` rule in stylesheet.css. Every other sensor type defines `padding: 0` plus a small right margin there; with the rule missing, GNOME Shell's generic `.system-status-icon` padding applied to the GPU icon, pushing its value text right and making the icon look smaller/misaligned.

Fix: normalize the style class in `_defaultIcon()` exactly like `_sensorIconPath()` already does (`gpu#N` -> `gpu`), so all GPUs share one matchable `vitals-panel-icon-gpu` class, and add the corresponding CSS rule following the existing per-sensor convention. No behavior change for non-GPU sensors.

## Why
This change resolves the target issue or improvement.

## How to test
Verify that the project builds/runs correctly and the specific bug/improvement is addressed.

Fixes #565