### PR TITLE
fix: replace St.BoxLayout's `vertical` with `orientation`

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -47,7 +47,7 @@ var VitalsMenuButton = GObject.registerClass({
         this._sensors = new Sensors.Sensors(this._settings, this._sensorIcons, _);
         this._values = new Values.Values(this._settings, this._sensorIcons);
         this._menuLayout = new St.BoxLayout({
-            vertical: false,
+            orientation: Clutter.Orientation.HORIZONTAL,
             clip_to_allocation: true,
             x_align: Clutter.ActorAlign.START,
             y_align: Clutter.ActorAlign.CENTER,
@@ -124,7 +124,7 @@ var VitalsMenuButton = GObject.registerClass({
 
         let customButtonBox = new St.BoxLayout({
             style_class: 'vitals-button-box',
-            vertical: false,
+            orientation: Clutter.Orientation.HORIZONTAL,
             clip_to_allocation: true,
             x_align: Clutter.ActorAlign.CENTER,
             y_align: Clutter.ActorAlign.CENTER,


### PR DESCRIPTION
Fixes compatibility with GNOME 51.rc (fixes #588).

I've not tested this with older GNOME versions.